### PR TITLE
#50 오늘의 맛집 캐싱 도입

### DIFF
--- a/src/main/java/com/matzip/place/application/port/RankingTempStore.java
+++ b/src/main/java/com/matzip/place/application/port/RankingTempStore.java
@@ -1,0 +1,17 @@
+package com.matzip.place.application.port;
+
+import com.matzip.place.api.response.PlaceRankingResponseDto;
+import com.matzip.place.domain.Campus;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface RankingTempStore {
+
+    Optional<List<PlaceRankingResponseDto>> get(LocalDate date, Campus campus);
+
+    void set(LocalDate date, Campus campus, List<PlaceRankingResponseDto> rankingResponseDtos);
+
+    void remove(LocalDate date, Campus campus);
+}

--- a/src/main/java/com/matzip/place/infra/cache/PlaceRankingTempStoreMemory.java
+++ b/src/main/java/com/matzip/place/infra/cache/PlaceRankingTempStoreMemory.java
@@ -1,0 +1,41 @@
+package com.matzip.place.infra.cache;
+
+import com.matzip.place.api.response.PlaceRankingResponseDto;
+import com.matzip.place.application.port.RankingTempStore;
+import com.matzip.place.domain.Campus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class PlaceRankingTempStoreMemory implements RankingTempStore {
+
+    private final Map<String, List<PlaceRankingResponseDto>> store = new ConcurrentHashMap<>();
+
+
+    @Override
+    public Optional<List<PlaceRankingResponseDto>> get(LocalDate date, Campus campus) {
+        String key = generateKey(date, campus);
+        return Optional.ofNullable(store.get(key));
+    }
+
+    @Override
+    public void set(LocalDate date, Campus campus, List<PlaceRankingResponseDto> rankingResponseDtos) {
+        String key = generateKey(date, campus);
+        store.put(key, rankingResponseDtos);
+    }
+
+    @Override
+    public void remove(LocalDate date, Campus campus) {
+        String key = generateKey(date, campus);
+        store.remove(key);
+    }
+
+    private String generateKey(LocalDate date, Campus campus) {
+        return date.toString() + ":" + campus.name();
+    }
+}

--- a/src/main/java/com/matzip/place/infra/scheduler/PlaceRankingScheduler.java
+++ b/src/main/java/com/matzip/place/infra/scheduler/PlaceRankingScheduler.java
@@ -1,0 +1,34 @@
+package com.matzip.place.infra.scheduler;
+
+import com.matzip.place.api.response.PlaceRankingResponseDto;
+import com.matzip.place.application.port.RankingTempStore;
+import com.matzip.place.application.service.PlaceReadService;
+import com.matzip.place.domain.Campus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceRankingScheduler {
+
+    private final PlaceReadService placeReadService;
+    private final RankingTempStore rankingTempStore;
+
+    @Scheduled(cron = "0 5 0 * * *")
+    public void cachePreviousDayPlaceRankings() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDate twoDaysAgo = LocalDate.now().minusDays(2);
+
+        Arrays.stream(Campus.values()).forEach(campus -> {
+            List<PlaceRankingResponseDto> ranking = placeReadService.getDailyRankingByViews(campus, yesterday);
+            rankingTempStore.set(yesterday, campus, ranking);
+
+            rankingTempStore.remove(twoDaysAgo, campus);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
오늘의 맛집 캐싱 도입

## ✅ 작업 내용

오늘의 맛집 API 호출시 오늘자 기준 등록된 모든 맛집의 상세 페이지 조회수가 0일 경우 빈 값을 반환하는 이슈 존재.
하여 캐싱 활용하여 3개 이상 맛집에 조회수 카운트시 오늘자 기준으로 맛집 반환하게 변경.

- [ ] 스케줄러를 활용하여 매일 `00:05`에 어제 조회수 기반 랭킹 캐싱


## 🎯 관련 이슈

- close #50 

## 💬 기타 공유하고 싶은 내용
- 스케줄러에서 랭킹 로직을 재사용하기 위해 `getDailyRankingByViews`를 `public`으로 변경했는데 이렇게 하면 캡슐화가 깨지는 거 같고, 서비스의 내부 구현이 외부에 노출되는 것 같아서 고민인 부분이 있습니다. 그래서 랭킹 계산 로직을 `RankingProvider` 같은 별도의 클래스로 분리하는 방법을 생각해봤는데 이건 괜찮은 방법일까요??