### PR TITLE
#53 'isLiked'가 'liked'로 반환되던 문제 해결

### DIFF
--- a/src/main/java/com/matzip/place/api/response/PlaceDetailResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.matzip.place.api.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.matzip.place.api.RecommendedMenuDto;
 import com.matzip.place.domain.entity.*;
 import com.matzip.place.dto.CategoryDto;
@@ -21,11 +22,13 @@ public class PlaceDetailResponseDto {
     private String address;
     private LocationDto location;
     private List<PhotoDto> photos;
-    private boolean isLiked;
     private String description;
     private List<RecommendedMenuDto> menus;
     private List<TagDto> tags;
     private List<CategoryDto> categories;
+
+    @Getter(onMethod_ = @JsonProperty("isLiked"))
+    private boolean isLiked;
 
     // 서비스 계층에서 모든 정보를 조합하여 DTO로 변환하는 정적 팩토리 메서드
     public static PlaceDetailResponseDto from(


### PR DESCRIPTION
## 📌 PR 제목
`isLiked` 필드가 `liked`로 반환되던 이슈 해결

## ✅ 작업 내용

- [x] `isLiked` 필드에 `@Getter(onMethod_ = @JsonProperty("isLiked"))` 어노테이션 사용


## 🎯 관련 이슈

- close #53 

## 💬 기타 공유하고 싶은 내용
[https://projectlombok.org/features/GetterSetter]()
