### PR TITLE
#55 카카오 로그인 CORS 에러 해결

### DIFF
--- a/src/main/java/com/matzip/auth/api/AuthController.java
+++ b/src/main/java/com/matzip/auth/api/AuthController.java
@@ -129,7 +129,7 @@ public class AuthController {
                 .build();
 
         // 3) 프론트 성공 URL로 302 리다이렉트 (필요 시 state를 그대로 붙여 전달)
-        String location = redirectProperties.getSuccessUri();
+        String location = redirectProperties.getSuccessPath();
         if (state != null && !state.isBlank()) {
             location = location + (location.contains("?") ? "&" : "?") + "state=" + state;
         }

--- a/src/main/java/com/matzip/common/config/AuthRedirectProperties.java
+++ b/src/main/java/com/matzip/common/config/AuthRedirectProperties.java
@@ -1,15 +1,24 @@
 package com.matzip.common.config;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "auth.redirect")
+@ConfigurationProperties(prefix = "matzip.auth")
 public class AuthRedirectProperties {
-    // 콜백 성공 시 리다이렉트할 url
-    private String successUri;
+
+    private List<String> allowedOrigins;
+
+    private String successPath;          // 예: /auth/callback/success
+
+    private String failurePath;
+
+    private String stateSecret;
 
     private boolean cookieSecure = true;
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,9 +22,12 @@ oauth2:
     client-id: ${KAKAO_CLIENT_ID}
     redirect-uri: ${KAKAO_PROD_REDIRECT_URI}
 
-auth:
-  redirect:
-    success-uri: ${KAKAO_FRONT_REDIRECT_URI}
+matzip:
+  auth:
+    allowed-origins: ${ALLOWED_ORIGINS}
+    success-path: /login/loding/success
+    failure-path: /login/loding/fail
+    state-secret: ${STATE_SIGNING_SECRET}
     cookie-secure: true
     cookie-same-site: Lax
 


### PR DESCRIPTION
## 📌 PR 제목
카카오 로그인 CORS 에러 해결

## ✅ 작업 내용

- [x] `application-prod.yml`에 허용 오리진 추가
- [x] `EC2` .env 파일 수정


## 🎯 관련 이슈

- close #55 

## 💬 기타 공유하고 싶은 내용

