### PR TITLE
#61 fix: state 값 Base64 인코딩 시 패딩 문자 제거

### DIFF
--- a/src/main/java/com/matzip/auth/application/util/StatelessStateSigner.java
+++ b/src/main/java/com/matzip/auth/application/util/StatelessStateSigner.java
@@ -37,11 +37,13 @@ public class StatelessStateSigner {
      * Origin을 서명하여 state 문자열 생성
      */
     public String createSignedState(String origin) {
-        String encodedOrigin = Base64.getUrlEncoder().encodeToString(origin.getBytes(StandardCharsets.UTF_8));
+        String encodedOrigin = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(origin.getBytes(StandardCharsets.UTF_8));
         String signature;
         synchronized (hmac) { // Mac은 thread-safe하지 않음
             byte[] signatureBytes = hmac.doFinal(encodedOrigin.getBytes(StandardCharsets.UTF_8));
-            signature = Base64.getUrlEncoder().encodeToString(signatureBytes);
+            signature = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(signatureBytes);
         }
         return encodedOrigin + "." + signature;
     }


### PR DESCRIPTION
## 📌 PR 제목
state 값 Base64 인코딩 시 패딩 문자 제거

## ✅ 작업 내용

- [ ] `StatelessStateSigner`에서 `Base64.getUrlEncoder()` 사용 시 `.withoutPadding()` 옵션을 추가하여 패딩 문자를 제거

## 🎯 관련 이슈

- close #61 