### PR TITLE
#66 프리뷰 응답에 isRecommended 필드 누락 이슈 수정

### DIFF
--- a/src/main/java/com/matzip/place/api/response/PlaceCheckResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceCheckResponseDto.java
@@ -1,7 +1,7 @@
 package com.matzip.place.api.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.matzip.place.dto.LocationDto;
-import com.matzip.place.dto.MenuDto;
 import com.matzip.place.dto.PhotoDto;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +21,7 @@ public class PlaceCheckResponseDto {
     // 미등록 프리뷰: 실제 사진/메뉴로 채움
     // 이미 등록: 빈 배열
     private List<PhotoDto> photos;
-    private List<MenuDto> menus;
+    private List<MenuItem> menus;
 
     @Getter
     @Builder
@@ -29,6 +29,8 @@ public class PlaceCheckResponseDto {
         private Long menuId;
         private String name;
         private int price;
+
+        @Getter(onMethod_ = @JsonProperty("isRecommended"))
         private boolean isRecommended; // 프리뷰 기본값: false
     }
 

--- a/src/main/java/com/matzip/place/application/service/PlaceService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceService.java
@@ -81,6 +81,7 @@ public class PlaceService {
         if (srcMenus != null) {
             for (MenuDto m : srcMenus) {
                 MenuItem item = MenuItem.builder()
+                        .menuId(m.getMenuId())
                         .name(m.getName())
                         .price(m.getPrice())
                         .isRecommended(false) // 프리뷰 단계이므로 항상 false
@@ -95,7 +96,7 @@ public class PlaceService {
                 .address(snap.address())
                 .location(LocationDto.of(snap.latitude(), snap.longitude()))
                 .photos(snap.photos())
-                .menus(snap.menus())
+                .menus(menuItems)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 PR 제목
프리뷰 응답에 isRecommended 필드 누락 이슈 수정

## ✅ 작업 내용

- [ ] 프리뷰 응답의 메뉴 리스트 타입을 `MenuDto`에서 `PlaceCheckResponseDto.MenuItem`으로 변경

## 🎯 관련 이슈

- close #66 

