### PR TITLE
#75 카카오 로그인 동적 리다이렉트 오류 해결

### DIFF
--- a/src/main/java/com/matzip/auth/application/util/StatelessStateSigner.java
+++ b/src/main/java/com/matzip/auth/application/util/StatelessStateSigner.java
@@ -62,7 +62,8 @@ public class StatelessStateSigner {
             String expectedSignature;
             synchronized (hmac) {
                 byte[] signatureBytes = hmac.doFinal(encodedOrigin.getBytes(StandardCharsets.UTF_8));
-                expectedSignature = Base64.getUrlEncoder().encodeToString(signatureBytes);
+                expectedSignature = Base64.getUrlEncoder().withoutPadding()
+                        .encodeToString(signatureBytes);
             }
 
             if (!Objects.equals(signature, expectedSignature)) {


### PR DESCRIPTION
## 📌 PR 제목
카카오 로그인 동적 리다이렉트 오류 해결

## ✅ 작업 내용

- [x] StatelessStateSigner 서명 검증 시 Base64 인코딩 패딩 불일치 수정

## 🎯 관련 이슈

- close #75

## 💬 기타 공유하고 싶은 내용

