### PR TITLE
#80 맛집 상세 페이지 API 호출 시 메뉴에 menuId 누락 수정

### DIFF
--- a/src/main/java/com/matzip/place/api/response/MenuResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/MenuResponseDto.java
@@ -1,18 +1,23 @@
-package com.matzip.place.api;
+package com.matzip.place.api.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.matzip.place.domain.entity.Menu;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class RecommendedMenuDto {
+public class MenuResponseDto {
+    private Long menuId;
     private String name;
     private int price;
+
+    @Getter(onMethod_ = @JsonProperty("isRecommended"))
     private boolean isRecommended;
 
-    public static RecommendedMenuDto from(Menu menu) {
-        return RecommendedMenuDto.builder()
+    public static MenuResponseDto from(Menu menu) {
+        return MenuResponseDto.builder()
+                .menuId(menu.getId())
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .isRecommended(menu.isRecommended())

--- a/src/main/java/com/matzip/place/api/response/PlaceDetailResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceDetailResponseDto.java
@@ -1,7 +1,6 @@
 package com.matzip.place.api.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.matzip.place.api.RecommendedMenuDto;
 import com.matzip.place.domain.entity.*;
 import com.matzip.place.dto.CategoryDto;
 import com.matzip.place.dto.LocationDto;
@@ -23,7 +22,7 @@ public class PlaceDetailResponseDto {
     private LocationDto location;
     private List<PhotoDto> photos;
     private String description;
-    private List<RecommendedMenuDto> menus;
+    private List<MenuResponseDto> menus;
     private List<TagDto> tags;
     private List<CategoryDto> categories;
 
@@ -46,7 +45,7 @@ public class PlaceDetailResponseDto {
                 .description(place.getDescription())
                 .location(LocationDto.of(place.getLatitude(), place.getLongitude()))
                 .photos(photos.stream().map(PhotoDto::from).collect(Collectors.toList()))
-                .menus(menus.stream().map(RecommendedMenuDto::from).collect(Collectors.toList()))
+                .menus(menus.stream().map(MenuResponseDto::from).collect(Collectors.toList()))
                 .categories(categories.stream().map(CategoryDto::from).collect(Collectors.toList()))
                 .tags(tags.stream().map(TagDto::from).collect(Collectors.toList()))
                 .isLiked(isLiked)


### PR DESCRIPTION
## 📌 PR 제목
맛집 상세 페이지 API 호출 시 메뉴에 menuId 누락 수정

## ✅ 작업 내용

- [ ] `MenuResponseDto `에 `menuId` 필드 누락 사항 수정

## 🎯 관련 이슈

- close #80 

## 💬 기타 공유하고 싶은 내용
