### PR TITLE
#82 이벤트 조회 API 인증 여부에 따른 응답 DTO 분리

### DIFF
--- a/src/main/java/com/matzip/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/matzip/common/security/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/events/**").authenticated()
+                        .requestMatchers("/api/v1/events/entries").authenticated()
 //                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/matzip/lottery/controller/LotteryEventController.java
+++ b/src/main/java/com/matzip/lottery/controller/LotteryEventController.java
@@ -3,7 +3,7 @@ package com.matzip.lottery.controller;
 import com.matzip.common.response.ApiResponse;
 import com.matzip.common.security.UserPrincipal;
 import com.matzip.lottery.controller.request.ParticipateEventRequest;
-import com.matzip.lottery.controller.response.LotteryEventResponse;
+import com.matzip.lottery.controller.response.LotteryEventView;
 import com.matzip.lottery.service.LotteryEventService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -24,8 +24,9 @@ public class LotteryEventController {
     }
 
     @GetMapping
-    public ApiResponse<LotteryEventResponse> findEvent(@AuthenticationPrincipal UserPrincipal user) {
-        LotteryEventResponse data = lotteryEventService.getCurrentEvent(user.getUserId());
+    public ApiResponse<LotteryEventView> findEvent(@AuthenticationPrincipal UserPrincipal user) {
+        Long userId = (user != null) ? user.getUserId() : null;
+        LotteryEventView data = lotteryEventService.getCurrentEvent(userId);
         return ApiResponse.success(data);
     }
 

--- a/src/main/java/com/matzip/lottery/controller/response/LotteryEventAnonymousResponse.java
+++ b/src/main/java/com/matzip/lottery/controller/response/LotteryEventAnonymousResponse.java
@@ -1,0 +1,20 @@
+package com.matzip.lottery.controller.response;
+
+import com.matzip.lottery.domain.LotteryEvent;
+import lombok.Builder;
+
+@Builder
+public record LotteryEventAnonymousResponse(LotteryEventResponse.PrizeResponse prize) implements LotteryEventView {
+
+    public static LotteryEventAnonymousResponse empty() {
+        return LotteryEventAnonymousResponse.builder()
+                .build();
+    }
+
+    public static LotteryEventAnonymousResponse of(LotteryEvent lotteryEvent) {
+        return LotteryEventAnonymousResponse.builder()
+                .prize(LotteryEventResponse.PrizeResponse.from(lotteryEvent.getPrize()))
+                .build();
+    }
+}
+

--- a/src/main/java/com/matzip/lottery/controller/response/LotteryEventResponse.java
+++ b/src/main/java/com/matzip/lottery/controller/response/LotteryEventResponse.java
@@ -8,7 +8,8 @@ import java.time.LocalDateTime;
 
 @Builder
 public record LotteryEventResponse(Long eventId, PrizeResponse prize, int totalWinnersCount, int participantsCount,
-                                   int usedTicketsCount, int remainingTicketsCount, LocalDateTime eventEndDate) {
+                                   int usedTicketsCount, int remainingTicketsCount, LocalDateTime eventEndDate)
+        implements LotteryEventView {
 
     public static LotteryEventResponse empty() {
         return LotteryEventResponse.builder()

--- a/src/main/java/com/matzip/lottery/controller/response/LotteryEventView.java
+++ b/src/main/java/com/matzip/lottery/controller/response/LotteryEventView.java
@@ -1,0 +1,5 @@
+package com.matzip.lottery.controller.response;
+
+public sealed interface LotteryEventView permits LotteryEventResponse, LotteryEventAnonymousResponse {
+}
+

--- a/src/main/java/com/matzip/lottery/service/LotteryEventService.java
+++ b/src/main/java/com/matzip/lottery/service/LotteryEventService.java
@@ -2,7 +2,9 @@ package com.matzip.lottery.service;
 
 import com.matzip.common.exception.BusinessException;
 import com.matzip.common.exception.code.ErrorCode;
+import com.matzip.lottery.controller.response.LotteryEventAnonymousResponse;
 import com.matzip.lottery.controller.response.LotteryEventResponse;
+import com.matzip.lottery.controller.response.LotteryEventView;
 import com.matzip.lottery.domain.LotteryEntries;
 import com.matzip.lottery.domain.LotteryEntry;
 import com.matzip.lottery.domain.LotteryEvent;
@@ -31,9 +33,13 @@ public class LotteryEventService {
     }
 
     @Transactional(readOnly = true)
-    public LotteryEventResponse getCurrentEvent(Long userId) {
+    public LotteryEventView getCurrentEvent(Long userId) {
         return lotteryEventRepository.findCurrentEvent(LocalDateTime.now())
                 .map(currentEvent -> {
+                    if (userId == null) {
+                        return LotteryEventAnonymousResponse.of(currentEvent);
+                    }
+
                     List<LotteryEntry> entries = lotteryEntryRepository.findByLotteryEvent(currentEvent);
                     LotteryEntries lotteryEntries = new LotteryEntries(entries);
 
@@ -43,7 +49,7 @@ public class LotteryEventService {
 
                     return LotteryEventResponse.of(currentEvent, participantsCount, usedTicketsCount, remainingTicketsCount);
                 })
-                .orElseGet(LotteryEventResponse::empty);
+                .orElseGet(() -> userId == null ? LotteryEventAnonymousResponse.empty() : LotteryEventResponse.empty());
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 PR 제목
이벤트 조회 API 인증 여부에 따른 응답 DTO 분리

## ✅ 작업 내용

- [ ] 인증 사용자 요청 시 `LotteryEventResponse` 유지
- [ ] 비인증 사용자 요청 시 `LotteryEventAnonymousResponse`로 경품 정보만 반환
- [ ] `LotteryEventView` 인터페이스 도입 및 서비스 분기 처리
- [ ] `SecurityConfig`에서 `/api/v1/events/entries`만 인증을 요구하게 변경

## 🎯 관련 이슈

- close #82 

## 💬 기타 공유하고 싶은 내용

