### PR TITLE
#86 JWT 토큰 만료 시 401 에러 반환하도록 수정

### DIFF
--- a/src/main/java/com/matzip/auth/application/AuthService.java
+++ b/src/main/java/com/matzip/auth/application/AuthService.java
@@ -116,8 +116,15 @@ public class AuthService {
         }
 
         // 1) RT 유효성 검증(만료/서명 등)
-        if (!jwtProvider.validateToken(requestRt)) {
-            throw new BusinessException(ErrorCode.INVALID_TOKEN, "유효하지 않은 리프레시 토큰입니다.");
+        JwtProvider.TokenValidationResult validationResult = jwtProvider.validateTokenWithResult(requestRt);
+        if (validationResult != JwtProvider.TokenValidationResult.VALID) {
+            ErrorCode errorCode = validationResult == JwtProvider.TokenValidationResult.EXPIRED 
+                    ? ErrorCode.TOKEN_EXPIRED 
+                    : ErrorCode.INVALID_TOKEN;
+            throw new BusinessException(errorCode, 
+                    validationResult == JwtProvider.TokenValidationResult.EXPIRED 
+                            ? "리프레시 토큰이 만료되었습니다." 
+                            : "유효하지 않은 리프레시 토큰입니다.");
         }
 
         // 2) subject(userId) 파싱

--- a/src/main/java/com/matzip/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/matzip/common/security/jwt/JwtProvider.java
@@ -73,22 +73,32 @@ public class JwtProvider {
     }
 
     /**
-     * 토큰 유효성 검증
+     * 토큰 검증 및 예외 타입 반환
+     * @return TokenValidationResult 토큰 검증 결과 (VALID, EXPIRED, INVALID)
      */
-    public boolean validateToken(String token) {
+    public TokenValidationResult validateTokenWithResult(String token) {
         try {
             Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
-            return true;
+            return TokenValidationResult.VALID;
         } catch (ExpiredJwtException e) {
             log.warn("JWT expired at {}", e.getClaims().getExpiration());
+            return TokenValidationResult.EXPIRED;
         } catch (SecurityException | MalformedJwtException e) {
             log.warn("JWT signature invalid or malformed: {}", e.getMessage());
+            return TokenValidationResult.INVALID;
         } catch (IllegalArgumentException e) {
             log.warn("JWT illegal argument (null/empty?): {}", e.getMessage());
+            return TokenValidationResult.INVALID;
         } catch (Exception e) {
             log.warn("JWT validate failed: {}", e.getMessage());
+            return TokenValidationResult.INVALID;
         }
-        return false;
+    }
+
+    public enum TokenValidationResult {
+        VALID,
+        EXPIRED,
+        INVALID
     }
 
 }

--- a/src/main/java/com/matzip/common/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/matzip/common/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,11 @@
 package com.matzip.common.security.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matzip.common.exception.code.ErrorCode;
+import com.matzip.common.response.ApiResponse;
 import com.matzip.common.security.jwt.JwtProvider;
 import com.matzip.common.security.UserPrincipal;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String TOKEN_PREFIX = "Bearer ";
 
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -33,16 +38,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 1. 요청 헤더에서 토큰 추출
         String token = resolveToken(request);
 
-        // 2. 토큰 유효성 검증
-        if (token != null && jwtProvider.validateToken(token)) {
-            // 3. 토큰이 유효하면 인증 정보를 생성하여 SecurityContext에 저장
-            Long userId = jwtProvider.getUserId(token);
-            UserPrincipal userPrincipal = new UserPrincipal(userId);
-            Authentication authentication = new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 2. 토큰이 있는 경우 유효성 검증
+        if (token != null) {
+            JwtProvider.TokenValidationResult validationResult = jwtProvider.validateTokenWithResult(token);
+            
+            if (validationResult == JwtProvider.TokenValidationResult.VALID) {
+                // 3. 토큰이 유효하면 인증 정보를 생성하여 SecurityContext에 저장
+                try {
+                    Long userId = jwtProvider.getUserId(token);
+                    UserPrincipal userPrincipal = new UserPrincipal(userId);
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (JwtException e) {
+                    // 토큰 파싱 중 예외 발생 시 401 반환
+                    handleJwtException(response, JwtProvider.TokenValidationResult.INVALID);
+                    return;
+                }
+            } else {
+                // 토큰이 만료되었거나 유효하지 않은 경우 401 반환
+                handleJwtException(response, validationResult);
+                return;
+            }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * JWT 예외 발생 시 401 응답 반환
+     */
+    private void handleJwtException(HttpServletResponse response, JwtProvider.TokenValidationResult validationResult) throws IOException {
+        ErrorCode errorCode;
+        
+        if (validationResult == JwtProvider.TokenValidationResult.EXPIRED) {
+            errorCode = ErrorCode.TOKEN_EXPIRED;
+        } else {
+            errorCode = ErrorCode.INVALID_TOKEN;
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        
+        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode);
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+        response.getWriter().write(jsonResponse);
     }
 
     // 요청 헤더에서 "Authorization" 헤더를 찾아 Bearer 토큰을 추출하는 메서드


### PR DESCRIPTION
## 📌 PR 제목
JWT 토큰 만료 시 401 에러 반환하도록 수정

## ✅ 작업 내용

- [ ] JwtProvider에 `validateTokenWithResult` 메서드 추가
  - 토큰 검증 결과를 `TokenValidationResult` enum으로 반환 (VALID, EXPIRED, INVALID)
  - 만료된 토큰과 유효하지 않은 토큰을 구분할 수 있도록 개선
- [ ] JwtAuthenticationFilter에서 토큰 검증 실패 시 401 응답 반환
  - 만료된 토큰: `TOKEN_EXPIRED` 에러 코드 반환
  - 유효하지 않은 토큰: `INVALID_TOKEN` 에러 코드 반환
- [ ] 기존 `validateToken` 메서드 제거
  - 중복 메서드를 제거하고 `validateTokenWithResult`로 통일하여 코드 일관성 향상

## 🎯 관련 이슈

- close #86 

