### PR TITLE
#79 검색 API 구현

### DIFF
--- a/src/main/java/com/matzip/place/api/controller/PlaceController.java
+++ b/src/main/java/com/matzip/place/api/controller/PlaceController.java
@@ -1,14 +1,20 @@
 package com.matzip.place.api.controller;
 
 import com.matzip.common.response.ApiResponse;
+import com.matzip.common.security.UserPrincipal;
 import com.matzip.place.api.request.PlaceCheckRequestDto;
 import com.matzip.place.api.request.PlaceRequestDto;
 import com.matzip.place.api.response.PlaceCheckResponseDto;
+import com.matzip.place.api.response.PlaceDetailResponseDto;
 import com.matzip.place.api.response.PlaceRegisterResponseDto;
+import com.matzip.place.application.service.PlaceReadService;
 import com.matzip.place.application.service.PlaceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class PlaceController {
 
     private final PlaceService placeService;
+    private final PlaceReadService placeReadService;
 
     // 프리뷰
     @GetMapping("/preview")
@@ -29,5 +36,14 @@ public class PlaceController {
     public ApiResponse<PlaceRegisterResponseDto> register(@Valid @RequestBody PlaceRequestDto req) {
         PlaceRegisterResponseDto data = placeService.register(req);
         return ApiResponse.success(data);
+    }
+
+    // 검색
+    @GetMapping("/search")
+    public ApiResponse<List<PlaceDetailResponseDto>> search(@RequestParam String keyword,
+                                                            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal != null ? userPrincipal.getUserId() : null;
+        List<PlaceDetailResponseDto> places = placeReadService.searchPlaceDetails(keyword, userId);
+        return ApiResponse.success(places);
     }
 }

--- a/src/main/java/com/matzip/place/application/service/PlaceReadService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceReadService.java
@@ -168,6 +168,15 @@ public class PlaceReadService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public List<PlaceDetailResponseDto> searchPlaceDetails(String keyword, Long userId) {
+        List<Place> places = placeRepository.searchByNameContaining(keyword);
+
+        return places.stream()
+                .map(place -> getPlaceDetail(place.getId(), userId))
+                .collect(Collectors.toList());
+    }
+
     private record PlaceRelatedData(List<Photo> photos,
                                     List<Category> categories,
                                     List<Tag> tags) {

--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -56,4 +56,11 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "AND p.status = 'APPROVED' " +
             "ORDER BY p.id DESC")
     List<Place> findByCategoryIdAndCampus(@Param("categoryId") Long categoryId, @Param("campus") Campus campus);
+
+    @EntityGraph(attributePaths = {"placeCategories.category", "placeTags.tag"})
+    @Query("SELECT p FROM Place p " +
+            "WHERE p.name LIKE CONCAT('%', :keyword, '%') " +
+            "AND p.status = 'APPROVED' " +
+            "ORDER BY p.id DESC")
+    List<Place> searchByNameContaining(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 📌 PR 제목
검색 API 구현

## ✅ 작업 내용

- [ ] 검색 API 구현
  - 가게 데이터 양이 많지 않을 것으로 예상돼서 `LIKE` 쿼리를 이용한 방식 사용

## 🎯 관련 이슈

- close #79 

## 💬 기타 공유하고 싶은 내용

