### PR TITLE
#92 맛집 등록 현황 목록/상세 조회 API 개발

### DIFF
--- a/src/main/java/com/matzip/admin/repository/RequestReviewRepository.java
+++ b/src/main/java/com/matzip/admin/repository/RequestReviewRepository.java
@@ -1,9 +1,14 @@
 package com.matzip.admin.repository;
 
 import com.matzip.admin.domain.RequestReview;
+import com.matzip.admin.domain.RequestReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RequestReviewRepository extends JpaRepository<RequestReview, Long> {
+
+    Optional<RequestReview> findTopByPlaceIdAndStatusOrderByCreatedAtDesc(Long placeId, RequestReviewStatus status);
 }

--- a/src/main/java/com/matzip/place/api/controller/PlaceRequestController.java
+++ b/src/main/java/com/matzip/place/api/controller/PlaceRequestController.java
@@ -1,0 +1,53 @@
+package com.matzip.place.api.controller;
+
+import com.matzip.admin.controller.response.PlaceRegisterRequestDetailResponse;
+import com.matzip.common.exception.BusinessException;
+import com.matzip.common.exception.code.ErrorCode;
+import com.matzip.common.response.ApiResponse;
+import com.matzip.common.security.UserPrincipal;
+import com.matzip.place.api.response.PlaceRegisterStatusDetailResponseDto;
+import com.matzip.place.api.response.PlaceRegisterStatusResponseDto;
+import com.matzip.place.application.service.PlaceReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/requests/places")
+public class PlaceRequestController {
+
+    private final PlaceReadService placeReadService;
+
+    @GetMapping
+    public ApiResponse<List<PlaceRegisterStatusResponseDto>> getMyPlaceRequests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        List<PlaceRegisterStatusResponseDto> response = placeReadService.getMyPlaceRequests(userPrincipal.getUserId());
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{placeId}")
+    public ApiResponse<PlaceRegisterStatusDetailResponseDto> getMyPlaceRequestDetail(
+            @PathVariable Long placeId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        PlaceRegisterStatusDetailResponseDto response = placeReadService.getMyPlaceRequestDetail(placeId, userPrincipal.getUserId());
+        return ApiResponse.success(response);
+    }
+
+
+}

--- a/src/main/java/com/matzip/place/api/response/PlaceRegisterStatusDetailResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceRegisterStatusDetailResponseDto.java
@@ -1,0 +1,64 @@
+package com.matzip.place.api.response;
+
+import com.matzip.place.domain.entity.Category;
+import com.matzip.place.domain.entity.Menu;
+import com.matzip.place.domain.entity.Photo;
+import com.matzip.place.domain.entity.Place;
+import com.matzip.place.domain.entity.Tag;
+import com.matzip.place.dto.CategoryDto;
+import com.matzip.place.dto.LocationDto;
+import com.matzip.place.dto.PhotoDto;
+import com.matzip.place.dto.TagDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class PlaceRegisterStatusDetailResponseDto {
+
+    private Long placeId;
+    private String placeName;
+    private LocalDate requestDate;
+    private List<PhotoDto> photos;
+    private String address;
+    private LocationDto location;
+    private String description;
+    private List<MenuResponseDto> menus;
+    private List<CategoryDto> categories;
+    private List<TagDto> tags;
+    private String registerStatus;
+    private String rejectedReason;
+
+    public static PlaceRegisterStatusDetailResponseDto from(Place place,
+                                                            List<Photo> photos,
+                                                            List<Menu> menus,
+                                                            List<Category> categories,
+                                                            List<Tag> tags,
+                                                            String rejectedReason) {
+        return PlaceRegisterStatusDetailResponseDto.builder()
+                .placeId(place.getId())
+                .placeName(place.getName())
+                .requestDate(place.getCreatedAt().toLocalDate())
+                .photos(photos.stream().map(PhotoDto::from).collect(Collectors.toList()))
+                .address(place.getAddress())
+                .location(LocationDto.of(place.getLatitude(), place.getLongitude()))
+                .description(place.getDescription())
+                .menus(menus.stream()
+                        .map(MenuResponseDto::from)
+                        .toList())
+                .categories(categories.stream()
+                        .map(CategoryDto::from)
+                        .toList())
+                .tags(tags.stream()
+                        .map(TagDto::from)
+                        .toList())
+                .registerStatus(place.getStatus().name())
+                .rejectedReason(rejectedReason)
+                .build();
+    }
+}

--- a/src/main/java/com/matzip/place/api/response/PlaceRegisterStatusResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceRegisterStatusResponseDto.java
@@ -1,0 +1,34 @@
+package com.matzip.place.api.response;
+
+import com.matzip.place.domain.entity.Place;
+import com.matzip.place.dto.CategoryDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class PlaceRegisterStatusResponseDto {
+
+    private Long placeId;
+    private String placeName;
+    private LocalDate requestDate;
+    private List<CategoryDto> categories;
+    private String registerStatus;
+
+    public static PlaceRegisterStatusResponseDto from(Place place) {
+        return PlaceRegisterStatusResponseDto.builder()
+                .placeId(place.getId())
+                .placeName(place.getName())
+                .requestDate(place.getCreatedAt().toLocalDate())
+                .categories(place.getCategories().stream()
+                        .map(CategoryDto::from)
+                        .collect(Collectors.toList()))
+                .registerStatus(place.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -1,8 +1,8 @@
 package com.matzip.place.infra.repository;
 
-import com.matzip.place.domain.entity.Place;
 import com.matzip.place.domain.Campus;
-import com.matzip.place.domain.PlaceStatus;
+import com.matzip.place.domain.entity.Place;
+import com.matzip.user.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -67,4 +67,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "AND p.status = 'APPROVED' " +
             "ORDER BY p.id DESC")
     List<Place> searchByNameContaining(@Param("keyword") String keyword);
+
+    @EntityGraph(attributePaths = {"placeCategories", "placeCategories.category", "placeTags", "placeTags.tag"})
+    List<Place> findAllByRegisteredByOrderByCreatedAtDesc(User registeredBy);
 }


### PR DESCRIPTION
## ✅ 작업 내용

- `PlaceReadService`: 목록 조회 시 `PlaceRepository.findAllByRegisteredByOrderByCreatedAtDesc` + `EntityGraph`로 카테고리/태그를 한 번에 로딩
- 거절 상태에서만 최신 `RequestReview`를 끌어오는 `resolveRejectedReason()` 추가
- `RequestReviewRepository`: `findTopByPlaceIdAndStatusOrderByCreatedAtDesc` 도입으로 최신 거절 리뷰만 조회

## 🎯 관련 이슈

- close #92 

## 💬 기타 공유하고 싶은 내용