### PR TITLE
#98 메뉴 이름으로 가게 검색 기능 개발

### DIFF
--- a/src/main/java/com/matzip/place/api/controller/PlaceController.java
+++ b/src/main/java/com/matzip/place/api/controller/PlaceController.java
@@ -6,6 +6,7 @@ import com.matzip.place.api.request.PlaceCheckRequestDto;
 import com.matzip.place.api.request.PlaceRequestDto;
 import com.matzip.place.api.response.PlaceCheckResponseDto;
 import com.matzip.place.api.response.PlaceRegisterResponseDto;
+import com.matzip.place.api.response.PlaceMenuSearchResponseDto;
 import com.matzip.place.api.response.PlaceSearchResponseDto;
 import com.matzip.place.application.service.PlaceReadService;
 import com.matzip.place.application.service.PlaceService;
@@ -45,10 +46,17 @@ public class PlaceController {
         return ApiResponse.success(data);
     }
 
-    // 검색
+    // 가게 이름으로 검색
     @GetMapping("/search")
     public ApiResponse<List<PlaceSearchResponseDto>> search(@RequestParam String keyword) {
         List<PlaceSearchResponseDto> places = placeReadService.searchPlaceDetails(keyword);
         return ApiResponse.success(places);
+    }
+
+    // 메뉴 이름으로 가게 검색
+    @GetMapping("/search/menu")
+    public ApiResponse<List<PlaceMenuSearchResponseDto>> searchByMenu(@RequestParam String keyword) {
+        List<PlaceMenuSearchResponseDto> results = placeReadService.searchPlaceByMenuName(keyword);
+        return ApiResponse.success(results);
     }
 }

--- a/src/main/java/com/matzip/place/api/response/PlaceMenuSearchResponseDto.java
+++ b/src/main/java/com/matzip/place/api/response/PlaceMenuSearchResponseDto.java
@@ -1,0 +1,22 @@
+package com.matzip.place.api.response;
+
+import com.matzip.place.domain.entity.Menu;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlaceMenuSearchResponseDto {
+
+    private Long placeId;
+    private String menuName;
+    private String placeName;
+
+    public static PlaceMenuSearchResponseDto from(Menu menu) {
+        return PlaceMenuSearchResponseDto.builder()
+                .placeId(menu.getPlace().getId())
+                .menuName(menu.getName())
+                .placeName(menu.getPlace().getName())
+                .build();
+    }
+}

--- a/src/main/java/com/matzip/place/application/service/PlaceReadService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceReadService.java
@@ -238,6 +238,14 @@ public class PlaceReadService {
                 .collect(Collectors.toList());
     }
 
+    public List<PlaceMenuSearchResponseDto> searchPlaceByMenuName(String keyword) {
+        List<Menu> menus = menuRepository.findByNameContainingAndPlaceApproved(keyword);
+
+        return menus.stream()
+                .map(PlaceMenuSearchResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
     public List<PlaceRegisterStatusResponseDto> getMyPlaceRequests(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/matzip/place/infra/repository/MenuRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/MenuRepository.java
@@ -3,9 +3,16 @@ package com.matzip.place.infra.repository;
 import com.matzip.place.domain.entity.Menu;
 import com.matzip.place.domain.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     List<Menu> findByPlaceOrderByIsRecommendedDescNameAsc(Place place);
+
+    @Query("SELECT m FROM Menu m JOIN FETCH m.place p " +
+            "WHERE m.name LIKE CONCAT('%', :keyword, '%') AND p.status = 'APPROVED' " +
+            "ORDER BY p.id, m.name")
+    List<Menu> findByNameContainingAndPlaceApproved(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 📌 PR 제목
메뉴 이름으로 가게 검색 API 개발

## ✅ 작업 내용

### API
- **엔드포인트:** `GET /api/v1/places/search/menu`
- **쿼리 파라미터:** `keyword` (검색어)

### 동작
- 키워드가 메뉴 이름에 포함된 메뉴를 조회하고, 해당 메뉴의 가게 정보를 함께 반환
- 한 가게에 매칭되는 메뉴가 여러 개면 각 메뉴마다 항목이 하나씩 반환됨

## 🎯 관련 이슈

- close #98 

## 💬 기타 공유하고 싶은 내용
