### PR TITLE
#102 APPROVED 상태만 중복 등록으로 처리

### DIFF
--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -1,6 +1,7 @@
 package com.matzip.place.infra.repository;
 
 import com.matzip.place.domain.Campus;
+import com.matzip.place.domain.PlaceStatus;
 import com.matzip.place.domain.entity.Place;
 import com.matzip.user.domain.User;
 import org.springframework.data.domain.Pageable;
@@ -16,8 +17,10 @@ import java.util.Optional;
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     boolean existsByKakaoPlaceId(String kakaoPlaceId);
+    boolean existsByKakaoPlaceIdAndStatus(String kakaoPlaceId, PlaceStatus status);
 
     Optional<Place> findByKakaoPlaceId(String kakaoPlaceId);
+    Optional<Place> findByKakaoPlaceIdAndStatus(String kakaoPlaceId, PlaceStatus status);
 
     @Query("SELECT p FROM Place p WHERE p.latitude BETWEEN :minLat AND :maxLat AND p.longitude BETWEEN :minLng AND :maxLng AND p.status = 'APPROVED'")
     List<Place> findWithinBounds(


### PR DESCRIPTION
## 📌 PR 제목
`APPROVED` 상태만 중복 등록으로 처리

## ✅ 작업 내용

- PlaceService.preview에서 "이미 등록된 맛집" 판정을 `kakaoPlaceId` + `APPROVED` 기준으로 변경
- PlaceService.register에서 기존 등록 처리 로직을 `APPROVED` 상태 우선으로 분기
- Optional 변수명 가독성 개선
    - maybe→ approvedPlaceOpt, existingPlaceOpt


## 🎯 관련 이슈

- close #102 

## 💬 기타 공유하고 싶은 내용

  - 기존에는 `REJECTED` 상태여도 이미 등록된 맛집으로 처리되는 이슈가 있었음
  - 중복 등록 예외/판정 기준을 `APPROVED`로 한정해 의도한 동작으로 수정

