### PR TITLE
#106 admin api 호출시 인증 필요 없도록 수정

### DIFF
--- a/src/main/java/com/matzip/common/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/matzip/common/security/jwt/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/auth",
             "/api/v1/places",
             "/api/v1/categories",
-            "/api/v1/events"
+            "/api/v1/events",
+            "/admin/api"
     );
 
     private final JwtProvider jwtProvider;


### PR DESCRIPTION
## 📌 PR 제목
admin api 호출시 인증 필요 없도록 수정

## ✅ 작업 내용

- [ ] `/admin/api` 경로 public으로 변경

## 🎯 관련 이슈

- close #106 

## 💬 기타 공유하고 싶은 내용
- `Next.js`에서 API 호출해서 크롬 개발자 도구에서 401 뜨는 게 안 보인듯
