### PR TITLE
#108 PENDING/REJECTED 상태인 가게에 대해 여러 요청 들어와도 insert row 되도록 수정

### DIFF
--- a/src/main/java/com/matzip/place/application/service/PlaceService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceService.java
@@ -113,14 +113,6 @@ public class PlaceService {
             return PlaceRegisterResponseDto.from(exists, existsCategories, existsTags);
         }
 
-        Optional<Place> existingPlaceOpt = placeRepository.findByKakaoPlaceId(kakaoPlaceId);
-        if (existingPlaceOpt.isPresent()) {
-            Place exists = existingPlaceOpt.get();
-            List<Category> existsCategories = extractCategoriesByPlace(exists);
-            List<Tag> existsTags = extractTagsByPlace(exists);
-            return PlaceRegisterResponseDto.from(exists, existsCategories, existsTags);
-        }
-
         PlaceSnapshot cachedSnapshot = placeTempStore.findById(kakaoPlaceId);
         if (cachedSnapshot == null) {
             throw new ValidationException(ErrorCode.VALIDATION_ERROR, "맛집 프리뷰 정보가 만료되었거나 존재하지 않습니다. 프리뷰를 다시 진행해주세요.");

--- a/src/main/java/com/matzip/place/domain/entity/Place.java
+++ b/src/main/java/com/matzip/place/domain/entity/Place.java
@@ -31,7 +31,7 @@ public class Place extends BaseEntity {
     @Column(name = "campus", nullable = false)
     private Campus campus;
 
-    @Column(name = "kakao_place_id", unique = true, nullable = false)
+    @Column(name = "kakao_place_id", nullable = false)
     private String kakaoPlaceId;
 
     @Column(name = "place_name", nullable = false, length = 100)

--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -16,10 +16,8 @@ import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-    boolean existsByKakaoPlaceId(String kakaoPlaceId);
     boolean existsByKakaoPlaceIdAndStatus(String kakaoPlaceId, PlaceStatus status);
 
-    Optional<Place> findByKakaoPlaceId(String kakaoPlaceId);
     Optional<Place> findByKakaoPlaceIdAndStatus(String kakaoPlaceId, PlaceStatus status);
 
     @Query("SELECT p FROM Place p WHERE p.latitude BETWEEN :minLat AND :maxLat AND p.longitude BETWEEN :minLng AND :maxLng AND p.status = 'APPROVED'")

--- a/src/test/java/com/matzip/place/application/PlaceServiceCachingTest.java
+++ b/src/test/java/com/matzip/place/application/PlaceServiceCachingTest.java
@@ -10,6 +10,7 @@ import com.matzip.place.api.response.PlaceCheckResponseDto;
 import com.matzip.place.application.port.PlaceTempStore;
 import com.matzip.place.domain.entity.Category;
 import com.matzip.place.domain.Campus;
+import com.matzip.place.domain.PlaceStatus;
 import com.matzip.place.infra.repository.*;
 import com.matzip.user.infra.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,7 @@ import static com.matzip.place.application.port.PlaceTempStore.PlaceSnapshot.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,7 +82,8 @@ class PlaceServiceCachingTest {
         PlaceTempStore.PlaceSnapshot cachedSnapshot = createMockPlaceSnapshot();
 
         Category category = createMockCategory(1L);
-        when(placeRepository.findByKakaoPlaceId(TEST_KAKAO_PLACE_ID)).thenReturn(Optional.empty());
+        when(placeRepository.findByKakaoPlaceIdAndStatus(eq(TEST_KAKAO_PLACE_ID), eq(PlaceStatus.APPROVED)))
+                .thenReturn(Optional.empty());
         when(placeTempStore.findById(TEST_KAKAO_PLACE_ID)).thenReturn(cachedSnapshot);
         when(categoryRepository.findAllById(List.of(1L))).thenReturn(List.of(category));
 

--- a/src/test/java/com/matzip/place/application/PlaceServiceTest.java
+++ b/src/test/java/com/matzip/place/application/PlaceServiceTest.java
@@ -4,6 +4,7 @@ import com.matzip.place.api.request.PlaceRequestDto;
 import com.matzip.place.application.port.PlaceTempStore;
 import com.matzip.place.application.service.PlaceService;
 import com.matzip.place.domain.Campus;
+import com.matzip.place.domain.PlaceStatus;
 import com.matzip.place.domain.entity.Category;
 import com.matzip.place.domain.entity.PlaceCategory;
 import com.matzip.place.infra.kakao.KakaoApiClient;
@@ -24,6 +25,7 @@ import java.util.Optional;
 import static com.matzip.place.application.port.PlaceTempStore.PlaceSnapshot.SMenu;
 import static com.matzip.place.application.port.PlaceTempStore.PlaceSnapshot.SPhoto;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +56,8 @@ class PlaceServiceTest {
         Category category1 = createMockCategory(1L);
         Category category2 = createMockCategory(2L);
 
-        when(placeRepository.findByKakaoPlaceId(TEST_KAKAO_PLACE_ID)).thenReturn(Optional.empty());
+        when(placeRepository.findByKakaoPlaceIdAndStatus(eq(TEST_KAKAO_PLACE_ID), eq(PlaceStatus.APPROVED)))
+                .thenReturn(Optional.empty());
         when(placeTempStore.findById(TEST_KAKAO_PLACE_ID)).thenReturn(createMockPlaceSnapshot());
         when(categoryRepository.findAllById(List.of(2L, 1L))).thenReturn(List.of(category1, category2));
 


### PR DESCRIPTION
## 📌 PR 제목
fix: PENDING/REJECTED 상태인 가게에 대해 여러 요청 들어와도 insert row 되도록 수정

## ✅ 작업 내용

### 문제 상황
`PENDING`, `REJECTED` 상태인 가게가 존재할 때 동일한 가게에 등록 요청이 들어오면 요청은 되지만 db에 요청 데이터가 쌓이지 않는 문제 발견.

### 원인
1. **애플리케이션 로직**  
   `PlaceService.register()`에서 `findByKakaoPlaceId(kakaoPlaceId)`로 **status 무관** 조회 후, 기존 Place가 있으면 새 row를 insert하지 않고 기존 데이터만 반환하고 있었음.  

2. **DB 제약**  
   `place.kakao_place_id`에 unique 제약이 있어, 위 로직을 수정해도 동일 `kakao_place_id`로 재등록 시 insert 시도 시 unique 위반으로 실패함.  
   → 재등록 요청을 여러 번 허용하려면 unique 제거 필요.

### 수정 사항
- **PlaceService**: `findByKakaoPlaceId` 기반 “기존 맛집 반환” 블록 제거.  
  `APPROVED`인 경우에만 기존 맛집으로 처리하고, 그 외에는 새 Place insert 하도록 변경.
- **Place 엔티티**: `kakao_place_id` 컬럼에서 `unique = true` 제거하여 동일 kakaoPlaceId에 대한 여러 row 허용.
- **PlaceRepository**: `findByKakaoPlaceId`, `existsByKakaoPlaceId` 제거.  
  `findByKakaoPlaceIdAndStatus`, `existsByKakaoPlaceIdAndStatus`만 사용하도록 정리.

## 🎯 관련 이슈

- close #108

## 💬 기타 공유하고 싶은 내용