### PR TITLE
#109 한 가게 승인 시 동일 kakaoPlaceId 나머지 PENDING 건 일괄 거절 처리

### DIFF
--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -20,6 +20,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByKakaoPlaceIdAndStatus(String kakaoPlaceId, PlaceStatus status);
 
+    List<Place> findByKakaoPlaceIdAndStatusAndIdNot(String kakaoPlaceId, PlaceStatus status, Long id);
+
     @Query("SELECT p FROM Place p WHERE p.latitude BETWEEN :minLat AND :maxLat AND p.longitude BETWEEN :minLng AND :maxLng AND p.status = 'APPROVED'")
     List<Place> findWithinBounds(
             @Param("minLat") double minLat, @Param("maxLat") double maxLat,


### PR DESCRIPTION
## 📌 PR 제목

feat(admin): 한 가게 승인 시 동일 kakaoPlaceId 나머지 PENDING 건 일괄 거절 처리

## ✅ 작업 내용

- 한 건을 `APPROVED` 처리할 때, 같은 `kakaoPlaceId`를 가진 나머지 `PENDING` 건을 자동으로 `REJECTED` 처리
- 자동 거절 시 고정 문구("동일한 장소가 먼저 등록되어 이번 신청은 반려되었습니다😭")로 거절 사유 저장 및 RequestReview 이력 생성

## 🎯 관련 이슈

- close #109

## 💬 기타 공유하고 싶은 내용


