### PR TITLE
#116 상품 수령을 위한 연락처 제공 API 구현

### DIFF
--- a/src/main/java/com/matzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/matzip/common/exception/code/ErrorCode.java
@@ -65,7 +65,10 @@ public enum ErrorCode {
 
     EVENT_ENDED(10000, HttpStatus.BAD_REQUEST, "종료된 이벤트입니다."),
     INSUFFICIENT_ENTRY_TICKETS(10001, HttpStatus.BAD_REQUEST, "응모권이 부족합니다."),
-    EVENT_NOT_PARTICIPATED(10002, HttpStatus.FORBIDDEN, "참여한 이벤트가 아닙니다.");
+    EVENT_NOT_PARTICIPATED(10002, HttpStatus.FORBIDDEN, "참여한 이벤트가 아닙니다."),
+    EVENT_NOT_WINNER(10003, HttpStatus.FORBIDDEN, "당첨자가 아닙니다."),
+    AGREEMENT_REQUIRED(10004, HttpStatus.BAD_REQUEST, "약관 및 개인정보 수집에 동의해 주세요."),
+    DRAW_NOT_COMPLETED(10005, HttpStatus.BAD_REQUEST, "이벤트 추첨이 완료된 후 상품 수령 신청이 가능합니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/matzip/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/matzip/common/security/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/events/entries").authenticated()
                         .requestMatchers("/api/v1/events/*/entries").authenticated()
+                        .requestMatchers("/api/v1/events/*/apply").authenticated()
 //                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/matzip/lottery/controller/LotteryEventController.java
+++ b/src/main/java/com/matzip/lottery/controller/LotteryEventController.java
@@ -2,7 +2,9 @@ package com.matzip.lottery.controller;
 
 import com.matzip.common.response.ApiResponse;
 import com.matzip.common.security.UserPrincipal;
+import com.matzip.lottery.controller.request.ApplyEventRequest;
 import com.matzip.lottery.controller.request.ParticipateEventRequest;
+import com.matzip.lottery.controller.response.ApplyEventResponse;
 import com.matzip.lottery.controller.response.EventEntryResultResponse;
 import com.matzip.lottery.controller.response.LotteryEventView;
 import com.matzip.lottery.controller.response.ParticipatedEventResponse;
@@ -45,6 +47,14 @@ public class LotteryEventController {
     public ApiResponse<EventEntryResultResponse> getEntryResult(@PathVariable Long eventId,
                                                                 @AuthenticationPrincipal UserPrincipal user) {
         EventEntryResultResponse data = lotteryEventService.getEntryResult(eventId, user.getUserId());
+        return ApiResponse.success(data);
+    }
+
+    @PostMapping("/{eventId}/apply")
+    public ApiResponse<ApplyEventResponse> applyForPrize(@PathVariable Long eventId,
+                                                         @Validated @RequestBody ApplyEventRequest request,
+                                                         @AuthenticationPrincipal UserPrincipal user) {
+        ApplyEventResponse data = lotteryEventService.applyForPrize(eventId, user.getUserId(), request);
         return ApiResponse.success(data);
     }
 

--- a/src/main/java/com/matzip/lottery/controller/request/ApplyEventRequest.java
+++ b/src/main/java/com/matzip/lottery/controller/request/ApplyEventRequest.java
@@ -1,0 +1,28 @@
+package com.matzip.lottery.controller.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+
+public record ApplyEventRequest(
+        @NotBlank(message = "핸드폰 번호를 입력해 주세요.")
+        @Pattern(regexp = "^010-\\d{3,4}-\\d{4}$", message = "올바른 핸드폰 번호 형식이 아닙니다. (예: 010-1234-5678)")
+        String phoneNumber,
+
+        @NotNull(message = "약관 동의 정보가 필요합니다.")
+        @Valid
+        AgreementsRequest agreements
+) {
+
+    public record AgreementsRequest(
+            boolean termsAgreed,
+            boolean privacyAgreed
+    ) {
+    }
+
+    public boolean isAllAgreed() {
+        return agreements != null && agreements.termsAgreed() && agreements.privacyAgreed();
+    }
+}

--- a/src/main/java/com/matzip/lottery/controller/response/ApplyEventResponse.java
+++ b/src/main/java/com/matzip/lottery/controller/response/ApplyEventResponse.java
@@ -1,0 +1,22 @@
+package com.matzip.lottery.controller.response;
+
+import com.matzip.lottery.domain.WinnerContact;
+import lombok.Builder;
+
+
+@Builder
+public record ApplyEventResponse(
+        String phoneNumber,
+        AgreementsResponse agreements
+) {
+
+    public record AgreementsResponse(boolean termsAgreed, boolean privacyAgreed) {
+    }
+
+    public static ApplyEventResponse from(WinnerContact contact) {
+        return ApplyEventResponse.builder()
+                .phoneNumber(contact.getPhoneNumber())
+                .agreements(new AgreementsResponse(contact.isTermsAgreed(), contact.isPrivacyAgreed()))
+                .build();
+    }
+}

--- a/src/main/java/com/matzip/lottery/domain/WinnerContact.java
+++ b/src/main/java/com/matzip/lottery/domain/WinnerContact.java
@@ -1,0 +1,48 @@
+package com.matzip.lottery.domain;
+
+import com.matzip.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"userId", "eventId"})
+})
+public class WinnerContact extends BaseEntity {
+
+    private Long userId;
+
+    private Long eventId;
+
+    @Column(nullable = false, length = 20)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private boolean termsAgreed;
+
+    @Column(nullable = false)
+    private boolean privacyAgreed;
+
+    protected WinnerContact() {
+    }
+
+    @Builder
+    public WinnerContact(Long userId, Long eventId, String phoneNumber, boolean termsAgreed, boolean privacyAgreed) {
+        this.userId = userId;
+        this.eventId = eventId;
+        this.phoneNumber = phoneNumber;
+        this.termsAgreed = termsAgreed;
+        this.privacyAgreed = privacyAgreed;
+    }
+
+    public void update(String phoneNumber, boolean termsAgreed, boolean privacyAgreed) {
+        this.phoneNumber = phoneNumber;
+        this.termsAgreed = termsAgreed;
+        this.privacyAgreed = privacyAgreed;
+    }
+}

--- a/src/main/java/com/matzip/lottery/repository/WinnerContactRepository.java
+++ b/src/main/java/com/matzip/lottery/repository/WinnerContactRepository.java
@@ -1,0 +1,13 @@
+package com.matzip.lottery.repository;
+
+import com.matzip.lottery.domain.WinnerContact;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface WinnerContactRepository extends JpaRepository<WinnerContact, Long> {
+
+    Optional<WinnerContact> findByUserIdAndEventId(Long userId, Long eventId);
+}

--- a/src/test/java/com/matzip/lottery/service/LotteryEventServiceGetEntryResultTest.java
+++ b/src/test/java/com/matzip/lottery/service/LotteryEventServiceGetEntryResultTest.java
@@ -9,6 +9,7 @@ import com.matzip.lottery.domain.Winner;
 import com.matzip.lottery.repository.LotteryEntryRepository;
 import com.matzip.lottery.repository.LotteryEventRepository;
 import com.matzip.lottery.repository.TicketRepository;
+import com.matzip.lottery.repository.WinnerContactRepository;
 import com.matzip.lottery.repository.WinnerRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -43,6 +45,8 @@ class LotteryEventServiceGetEntryResultTest {
     private LotteryEntryRepository lotteryEntryRepository;
     @Mock
     private WinnerRepository winnerRepository;
+    @Mock
+    private WinnerContactRepository winnerContactRepository;
 
     private static LotteryEvent createEvent(Long eventId) {
         LotteryEvent event = LotteryEvent.builder()
@@ -74,6 +78,7 @@ class LotteryEventServiceGetEntryResultTest {
             BDDMockito.given(lotteryEntryRepository.countParticipantsByLotteryEvent(event)).willReturn(127);
             BDDMockito.given(winnerRepository.findByUserIdAndEventId(USER_ID, EVENT_ID))
                     .willReturn(Optional.of(Winner.builder().userId(USER_ID).eventId(EVENT_ID).build()));
+            BDDMockito.given(winnerContactRepository.findByUserIdAndEventId(anyLong(), anyLong())).willReturn(Optional.empty());
 
             // when
             EventEntryResultResponse result = lotteryEventService.getEntryResult(EVENT_ID, USER_ID);
@@ -98,6 +103,7 @@ class LotteryEventServiceGetEntryResultTest {
             BDDMockito.given(lotteryEntryRepository.countByLotteryEventIdAndUserId(EVENT_ID, USER_ID)).willReturn(1);
             BDDMockito.given(lotteryEntryRepository.countParticipantsByLotteryEvent(event)).willReturn(50);
             BDDMockito.given(winnerRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).willReturn(Optional.empty());
+            BDDMockito.given(winnerContactRepository.findByUserIdAndEventId(anyLong(), anyLong())).willReturn(Optional.empty());
 
             // when
             EventEntryResultResponse result = lotteryEventService.getEntryResult(EVENT_ID, USER_ID);


### PR DESCRIPTION
## 📌 PR 제목
상품 수령을 위한 연락처 제공 API 구현

## ✅ 작업 내용

- `POST /api/v1/events/{eventId}/apply` 당첨자 연락처, 개인정보 수집 동의 여부 제출 API 추가
- 당첨자만 신청 가능, 추첨 미완료 시 `DRAW_NOT_COMPLETED`, 비당첨 시 `EVENT_NOT_WINNER` 반환
- `getEntryResult`의 `isPhoneSubmitted`를 WinnerContact 기준으로 조회하도록 연동 

## 🎯 관련 이슈

- close #116 

## 💬 기타 공유하고 싶은 내용
