### PR TITLE
#124 이벤트 당첨자 연락처 등록 시 Discord 웹훅 알림 기능 구현

### DIFF
--- a/src/main/java/com/matzip/MatzipServerApplication.java
+++ b/src/main/java/com/matzip/MatzipServerApplication.java
@@ -1,6 +1,7 @@
 package com.matzip;
 
 import com.matzip.common.config.AuthRedirectProperties;
+import com.matzip.common.config.DiscordWebhookProperties;
 import com.matzip.common.config.JwtProperties;
 import com.matzip.common.config.KakaoProperties;
 import org.springframework.boot.SpringApplication;
@@ -12,7 +13,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 @EnableConfigurationProperties({JwtProperties.class,
 		AuthRedirectProperties.class,
-		KakaoProperties.class})
+		KakaoProperties.class,
+		DiscordWebhookProperties.class})
 public class MatzipServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/matzip/common/config/DiscordWebhookProperties.java
+++ b/src/main/java/com/matzip/common/config/DiscordWebhookProperties.java
@@ -1,0 +1,15 @@
+package com.matzip.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "app.discord")
+public class DiscordWebhookProperties {
+
+    private String webhookUrl = "";
+}

--- a/src/main/java/com/matzip/lottery/infra/discord/DiscordWinnerNotificationService.java
+++ b/src/main/java/com/matzip/lottery/infra/discord/DiscordWinnerNotificationService.java
@@ -1,0 +1,62 @@
+package com.matzip.lottery.infra.discord;
+
+import com.matzip.common.config.DiscordWebhookProperties;
+import com.matzip.lottery.domain.LotteryEvent;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+public class DiscordWinnerNotificationService {
+
+    private final WebClient.Builder webClientBuilder;
+    private final DiscordWebhookProperties discordWebhookProperties;
+
+    public DiscordWinnerNotificationService(WebClient.Builder webClientBuilder,
+                                            DiscordWebhookProperties discordWebhookProperties) {
+        this.webClientBuilder = webClientBuilder;
+        this.discordWebhookProperties = discordWebhookProperties;
+    }
+
+
+    @Async
+    public void notifyWinnerContactSubmitted(LotteryEvent event, Long userId, String phoneNumber) {
+        String webhookUrl = discordWebhookProperties.getWebhookUrl();
+        if (!StringUtils.hasText(webhookUrl)) {
+            log.debug("Discord webhook URL이 설정되지 않아 알림을 건너뜁니다.");
+            return;
+        }
+
+        String content = buildMessage(event, userId, phoneNumber);
+        Map<String, String> body = Map.of("content", content);
+
+        try {
+            webClientBuilder.build()
+                    .post()
+                    .uri(webhookUrl)
+                    .bodyValue(body)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+            log.info("[Discord 알림] 이벤트 당첨자 연락처 제출 알림 전송 완료. eventId: {}, userId: {}", event.getId(), userId);
+        } catch (Exception e) {
+            log.warn("[Discord 알림] 웹훅 전송 실패. eventId: {}, userId: {}, error: {}", event.getId(), userId, e.getMessage());
+        }
+    }
+
+    private String buildMessage(LotteryEvent event, Long userId, String phoneNumber) {
+        String prizeDesc = event.getPrize() != null ? event.getPrize().getDescription() : "-";
+        return """
+                **이벤트 당첨자 연락처 제출**
+                - 이벤트 ID: %d
+                - 상품: %s
+                - 유저 ID: %d
+                - 연락처: %s
+                """
+                .formatted(event.getId(), prizeDesc, userId, phoneNumber);
+    }
+}

--- a/src/main/java/com/matzip/lottery/service/LotteryEventService.java
+++ b/src/main/java/com/matzip/lottery/service/LotteryEventService.java
@@ -17,6 +17,7 @@ import com.matzip.lottery.domain.WinnerContact;
 import com.matzip.lottery.repository.LotteryEntryRepository;
 import com.matzip.lottery.repository.LotteryEventRepository;
 import com.matzip.lottery.repository.TicketRepository;
+import com.matzip.lottery.infra.discord.DiscordWinnerNotificationService;
 import com.matzip.lottery.repository.WinnerContactRepository;
 import com.matzip.lottery.repository.WinnerRepository;
 import org.springframework.data.domain.Sort;
@@ -34,15 +35,18 @@ public class LotteryEventService {
     private final LotteryEntryRepository lotteryEntryRepository;
     private final WinnerRepository winnerRepository;
     private final WinnerContactRepository winnerContactRepository;
+    private final DiscordWinnerNotificationService discordWinnerNotificationService;
 
     public LotteryEventService(LotteryEventRepository lotteryEventRepository, TicketRepository ticketRepository,
                                LotteryEntryRepository lotteryEntryRepository, WinnerRepository winnerRepository,
-                               WinnerContactRepository winnerContactRepository) {
+                               WinnerContactRepository winnerContactRepository,
+                               DiscordWinnerNotificationService discordWinnerNotificationService) {
         this.lotteryEventRepository = lotteryEventRepository;
         this.ticketRepository = ticketRepository;
         this.lotteryEntryRepository = lotteryEntryRepository;
         this.winnerRepository = winnerRepository;
         this.winnerContactRepository = winnerContactRepository;
+        this.discordWinnerNotificationService = discordWinnerNotificationService;
     }
 
     @Transactional(readOnly = true)
@@ -128,6 +132,8 @@ public class LotteryEventService {
                         .termsAgreed(request.agreements().termsAgreed())
                         .privacyAgreed(request.agreements().privacyAgreed())
                         .build()));
+
+        discordWinnerNotificationService.notifyWinnerContactSubmitted(event, userId, request.phoneNumber());
 
         return ApplyEventResponse.from(contact);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,7 @@ spring:
 
 server:
   port: 8080
+
+app:
+  discord:
+    webhook-url: ${DISCORD_WEBHOOK_URL:}


### PR DESCRIPTION
## 📌 PR 제목
이벤트 당첨자 연락처 제출 시 Discord 웹훅 알림 

## ✅ 작업 내용

-  **당첨자 연락처 제출 시 Discord 알림**: `POST /api/v1/events/{eventId}/apply` 로 연락처가 제출되면 Discord 웹훅으로 알림 전송
-  **비동기 처리**: 웹훅 전송을 `@Async` 로 비동기 실행해 웹훅 실패 시에도 연락처 저장/응답에는 영향 없도록 처리
-  **설정 기반 동작**: `app.discord.webhook-url` (또는 `DISCORD_WEBHOOK_URL` 환경 변수) 미설정 시 알림 비활성화

## 🔄 비동기 처리 상세

| 구분 | 내용 |
|------|------|
| **목적** | Discord 웹훅 호출이 API 응답 시간을 늦추지 않도록 하고, 웹훅 장애가 당첨 연락처 제출 성공 여부에 영향을 주지 않도록 함 |
| **구현** | `DiscordWinnerNotificationService.notifyWinnerContactSubmitted()` 에 `@Async` 적용 → 기존 `AsyncConfiguration` 의 스레드 풀에서 실행 |
| **동작** | 연락처 저장(DB 커밋) 후 웹훅 전송을 별도 스레드에서 실행. 전송 실패 시 로그만 남기고 예외를 삼킴(연락처 저장은 이미 완료된 상태) |
| **선택 비활성화** | `webhook-url` 이 비어 있으면 메서드 진입 시 바로 return 하여 네트워크 호출 없이 종료 |



## 🎯 관련 이슈

- close #124 

## 💬 기타 공유하고 싶은 내용
