### PR TITLE
#125 Discord 웹훅 공통화 + 맛집 등록 신청 시 Discord 알림 추가

### DIFF
--- a/src/main/java/com/matzip/common/infra/discord/DiscordWebhookSender.java
+++ b/src/main/java/com/matzip/common/infra/discord/DiscordWebhookSender.java
@@ -1,0 +1,47 @@
+package com.matzip.common.infra.discord;
+
+import com.matzip.common.config.DiscordWebhookProperties;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class DiscordWebhookSender {
+
+    private final WebClient.Builder webClientBuilder;
+    private final DiscordWebhookProperties discordWebhookProperties;
+
+    public DiscordWebhookSender(WebClient.Builder webClientBuilder,
+                                DiscordWebhookProperties discordWebhookProperties) {
+        this.webClientBuilder = webClientBuilder;
+        this.discordWebhookProperties = discordWebhookProperties;
+    }
+
+    @Async
+    public void sendAsync(String content) {
+        String webhookUrl = discordWebhookProperties.getWebhookUrl();
+        if (!StringUtils.hasText(webhookUrl)) {
+            log.debug("Discord webhook URL이 설정되지 않아 알림을 건너뜁니다.");
+            return;
+        }
+
+        Map<String, String> body = Map.of("content", content);
+
+        try {
+            webClientBuilder.build()
+                    .post()
+                    .uri(webhookUrl)
+                    .bodyValue(body)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+            log.info("[Discord 알림] 전송 완료");
+        } catch (Exception e) {
+            log.warn("[Discord 알림] 웹훅 전송 실패. error: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/matzip/lottery/infra/discord/DiscordWinnerNotificationService.java
+++ b/src/main/java/com/matzip/lottery/infra/discord/DiscordWinnerNotificationService.java
@@ -1,51 +1,21 @@
 package com.matzip.lottery.infra.discord;
 
-import com.matzip.common.config.DiscordWebhookProperties;
+import com.matzip.common.infra.discord.DiscordWebhookSender;
 import com.matzip.lottery.domain.LotteryEvent;
-import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
-import org.springframework.web.reactive.function.client.WebClient;
 
-@Slf4j
 @Service
 public class DiscordWinnerNotificationService {
 
-    private final WebClient.Builder webClientBuilder;
-    private final DiscordWebhookProperties discordWebhookProperties;
+    private final DiscordWebhookSender discordWebhookSender;
 
-    public DiscordWinnerNotificationService(WebClient.Builder webClientBuilder,
-                                            DiscordWebhookProperties discordWebhookProperties) {
-        this.webClientBuilder = webClientBuilder;
-        this.discordWebhookProperties = discordWebhookProperties;
+    public DiscordWinnerNotificationService(DiscordWebhookSender discordWebhookSender) {
+        this.discordWebhookSender = discordWebhookSender;
     }
 
-
-    @Async
     public void notifyWinnerContactSubmitted(LotteryEvent event, Long userId, String phoneNumber) {
-        String webhookUrl = discordWebhookProperties.getWebhookUrl();
-        if (!StringUtils.hasText(webhookUrl)) {
-            log.debug("Discord webhook URL이 설정되지 않아 알림을 건너뜁니다.");
-            return;
-        }
-
         String content = buildMessage(event, userId, phoneNumber);
-        Map<String, String> body = Map.of("content", content);
-
-        try {
-            webClientBuilder.build()
-                    .post()
-                    .uri(webhookUrl)
-                    .bodyValue(body)
-                    .retrieve()
-                    .toBodilessEntity()
-                    .block();
-            log.info("[Discord 알림] 이벤트 당첨자 연락처 제출 알림 전송 완료. eventId: {}, userId: {}", event.getId(), userId);
-        } catch (Exception e) {
-            log.warn("[Discord 알림] 웹훅 전송 실패. eventId: {}, userId: {}, error: {}", event.getId(), userId, e.getMessage());
-        }
+        discordWebhookSender.sendAsync(content);
     }
 
     private String buildMessage(LotteryEvent event, Long userId, String phoneNumber) {

--- a/src/main/java/com/matzip/place/application/service/PlaceService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceService.java
@@ -15,6 +15,7 @@ import com.matzip.place.application.port.PlaceTempStore;
 import com.matzip.place.infra.repository.*;
 import com.matzip.user.domain.User;
 import com.matzip.user.infra.UserRepository;
+import com.matzip.common.infra.discord.DiscordWebhookSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +45,7 @@ public class PlaceService {
     private final PlaceTagRepository placeTagRepository;
     private final UserRepository userRepository;
     private final PlaceTempStore placeTempStore;
+    private final DiscordWebhookSender discordWebhookSender;
 
     public PlaceCheckResponseDto preview(PlaceCheckRequestDto req) {
         final String kakaoPlaceId = req.getKakaoPlaceId();
@@ -229,7 +231,22 @@ public class PlaceService {
 
         placeTempStore.remove(kakaoPlaceId);
 
+        notifyPlaceRegistrationRequest(place);
+
         return PlaceRegisterResponseDto.from(place, categories, tags);
+    }
+
+    private void notifyPlaceRegistrationRequest(Place place) {
+        Long userId = place.getRegisteredBy() != null ? place.getRegisteredBy().getId() : null;
+        String userIdStr = userId != null ? String.valueOf(userId) : "비회원";
+        String content = """
+                **맛집 등록 신청**
+                - 유저 ID: %s
+                - 캠퍼스: %s
+                - 가게명: %s
+                """
+                .formatted(userIdStr, place.getCampus(), place.getName());
+        discordWebhookSender.sendAsync(content);
     }
 
 


### PR DESCRIPTION
## 📌 PR 제목
Discord 웹훅 공통화 + 맛집 등록 신청 시 Discord 알림 추가

## ✅ 작업 내용

- **Discord 웹훅 전송 로직 공통화**: `DiscordWebhookSender` 추출, 당첨자 알림 서비스 리팩토링
- **맛집 등록 신청 Discord 알림**: `POST /api/v1/places` 성공 시 userId, campus, 가게명 포함 메시지 비동기 전송

## 구조를 왜 이렇게 짰는지
### 기존 구조의 한계
- `DiscordWinnerNotificationService` 한 클래스가 **메시지 포맷 생성**과 **웹훅 전송(URL 체크, HTTP POST, @Async, 예외 처리)** 을 모두 담당하고 있었음.
- 맛집 등록 알림을 추가하려면 같은 전송 로직을 또 구현하거나, 당첨자 전용 서비스를 복제해야 하는 문제가 있었음.

### 변경 방향: 전송 책임 분리
- **공통**: “문자열 content를 Discord 웹훅으로 비동기 전송”만 담당하는 `DiscordWebhookSender` 를 두었음.
  - URL 없으면 스킵, POST 실패 시 로그만 남기고 예외는 전파하지 않음 → 알림 실패가 비즈니스(등록/연락처 제출)에 영향을 주지 않도록 유지.
- **도메인별**: “어떤 메시지를 보낼지”만 각 서비스에서 담당.
  - **당첨자**: `DiscordWinnerNotificationService` → 당첨자용 메시지 생성 후 `DiscordWebhookSender.sendAsync(content)` 호출.
  - **맛집 등록**: `PlaceService` → 등록 성공 후 맛집 등록용 메시지 생성해 `DiscordWebhookSender.sendAsync(content)` 호출.

이렇게 해서 **전송 방식(비동기, URL, 에러 처리)은 한 곳에서만 관리**하고, **알림 종류가 늘어나도 메시지 포맷만 추가**하면 되도록 했음.


## 🎯 관련 이슈

- close #125

## 💬 기타 공유하고 싶은 내용
- 맛집 등록은 비회원도 가능하므로, `registeredBy`가 없을 때는 유저 ID 대신 `"비회원"`으로 표시
