### PR TITLE
#134 랭킹 API에 최근 등록 순(LATEST) 정렬 옵션 추가

### DIFF
--- a/src/main/java/com/matzip/place/application/service/PlaceReadService.java
+++ b/src/main/java/com/matzip/place/application/service/PlaceReadService.java
@@ -43,6 +43,7 @@ public class PlaceReadService {
     private final RequestReviewRepository requestReviewRepository;
 
     private static final int RANKING_SIZE = 3;
+    private static final int LATEST_PLACES_SIZE = 5;
 
     @Transactional
     public PlaceDetailResponseDto getPlaceDetail(Long placeId, Long userId) {
@@ -99,7 +100,11 @@ public class PlaceReadService {
         if (sortType == SortType.VIEWS) {
             return getDailyRankingByViews(campus);
         }
-        
+
+        if (sortType == SortType.LATEST) {
+            return getRankingByLatest(campus);
+        }
+
         return getRankingByLikes(campus);
     }
 
@@ -131,6 +136,20 @@ public class PlaceReadService {
 
         Map<Long, PlaceRelatedData> relatedDataMap = getPlaceRelatedDataInBatch(places);
         
+        return places.stream()
+                .map(place -> {
+                    PlaceRelatedData relatedData = relatedDataMap.get(place.getId());
+                    return PlaceCommonResponseDto.from(place, relatedData.categories(), relatedData.tags());
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<PlaceCommonResponseDto> getRankingByLatest(Campus campus) {
+        Pageable topN = PageRequest.of(0, LATEST_PLACES_SIZE);
+        List<Place> places = placeRepository.findTopByCampusOrderByCreatedAtDesc(campus, topN);
+
+        Map<Long, PlaceRelatedData> relatedDataMap = getPlaceRelatedDataInBatch(places);
+
         return places.stream()
                 .map(place -> {
                     PlaceRelatedData relatedData = relatedDataMap.get(place.getId());

--- a/src/main/java/com/matzip/place/domain/SortType.java
+++ b/src/main/java/com/matzip/place/domain/SortType.java
@@ -2,5 +2,6 @@ package com.matzip.place.domain;
 
 public enum SortType {
     LIKES,
-    VIEWS
+    VIEWS,
+    LATEST
 }

--- a/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
+++ b/src/main/java/com/matzip/place/infra/repository/PlaceRepository.java
@@ -64,6 +64,9 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("SELECT p FROM Place p WHERE p.campus = :campus AND p.status = 'APPROVED' ORDER BY p.likeCount DESC")
     List<Place> findTopByCampusOrderByLikeCount(@Param("campus") Campus campus, Pageable pageable);
 
+    @Query("SELECT p FROM Place p WHERE p.campus = :campus AND p.status = 'APPROVED' ORDER BY p.createdAt DESC")
+    List<Place> findTopByCampusOrderByCreatedAtDesc(@Param("campus") Campus campus, Pageable pageable);
+
     @EntityGraph(attributePaths = {"placeCategories.category", "placeTags.tag"})
     @Query("SELECT p FROM Place p " +
             "WHERE p.name LIKE CONCAT('%', :keyword, '%') " +


### PR DESCRIPTION
## 📌 PR 제목
랭킹 API에 최근 등록 순(LATEST) 정렬 옵션 추가

## ✅ 작업 내용

- `SortType`에 `LATEST` 추가 (최근 등록 순)
- 랭킹 API(`GET /api/v1/places/ranking`)에서 `sort=LATEST` 시 최근 등록 순 5개 맛집 반환
- `PlaceReadService`에 `getRankingByLatest()` 추가 및 `getRanking()`에서 `LATEST` 분기 처리

## 🎯 관련 이슈

- close #134

## 💬 기타 공유하고 싶은 내용

- `sort=LATEST`일 때만 5개, 기존 LIKES/VIEWS는 3개(`RANKING_SIZE`) 유지
- 승인된 맛집만 `createdAt` 기준 내림차순으로 반환